### PR TITLE
simplify n-ball constraint logic

### DIFF
--- a/src/main/java/com/manyangled/gibbous/optim/convex/QuadraticFunction.java
+++ b/src/main/java/com/manyangled/gibbous/optim/convex/QuadraticFunction.java
@@ -111,7 +111,7 @@ public class QuadraticFunction extends TwiceDifferentiableFunction {
     }
 
     /**
-     * Create a quadratic function that corresponds to s(x-c).s(x-c) &lt; r^2.
+     * Create a quadratic function that corresponds to s((x-c).(x-c) &lt; r^2).
      * That is, constrained to an n-dimensional ball of radius r, with scaling factor s.
      *
      * @param center the center of the n-ball

--- a/src/main/java/com/manyangled/gibbous/optim/convex/QuadraticFunction.java
+++ b/src/main/java/com/manyangled/gibbous/optim/convex/QuadraticFunction.java
@@ -89,7 +89,7 @@ public class QuadraticFunction extends TwiceDifferentiableFunction {
     }
 
     /**
-     * Create a quadratic function that corresponds to s(x-c).s(x-c) &lt; r^2.
+     * Create a quadratic function that corresponds to s((x-c).(x-c) &lt; r^2).
      * That is, constrained to an n-dimensional ball of radius r, with scaling factor s.
      *
      * @param center the center of the n-ball
@@ -102,11 +102,11 @@ public class QuadraticFunction extends TwiceDifferentiableFunction {
         if (n < 1) throw new IllegalArgumentException("center vector must have dimension > 0");
         if (s <= 0.0) throw new IllegalArgumentException("scale s must be > 0");
         if (r <= 0.0) throw new IllegalArgumentException("radius r must be > 0");
-        double[] all1 = new double[n];
-        java.util.Arrays.fill(all1, s*s);
-        RealMatrix A = new DiagonalMatrix(all1);
-        RealVector b = center.mapMultiply(-(s*s));
-        double c = 0.5 * (s*s*center.dotProduct(center) - r*r);
+        double[] alls = new double[n];
+        java.util.Arrays.fill(alls, s);
+        RealMatrix A = new DiagonalMatrix(alls);
+        RealVector b = center.mapMultiply(-s);
+        double c = 0.5 * ((s * center.dotProduct(center)) - (r * r));
         return new QuadraticFunction(A, b, c);
     }
 


### PR DESCRIPTION
Simplify the logic around the use of the n-ball constraint for feasible point solving, by constructing a ball of radius 2s, where (s) is the maximum (positive) value over all constraint functions. The n-ball quadratic is also scaled by `1/(2s)^2` so that the its minimum value remains constant as radius changes, and the n-ball constraint does not dominate the computations